### PR TITLE
added more ARIA, including haspopup and aria-label

### DIFF
--- a/src/Menu.js
+++ b/src/Menu.js
@@ -47,12 +47,20 @@ class Item {
         let element = document.createElement('button');
         element.className  = `menu-item menu-item__${this.type}`;
         element.setAttribute('role','menuitem');
-        element.setAttribute('title', this.label);
-
+        // element.setAttribute('title', this.label); // removed title because it'll be redundant in some screen readers, and not available to keyboard-only users
+    
         let icon = document.createElement('span');
         icon.className = "menu-item-icon";
-        if(this.icon) 
+        if(this.icon) {
+            
+            if(ItemType.Back == this.type) {
+                element.setAttribute('aria-label', "Back to previous level: "+this.label); // screen reader will read 'back to previous level' and visible text
+            } else {
+                element.setAttribute('aria-label', this.label); // add aria-label on the BUTTONS containing icons that don't have visible text
+            }
             icon.appendChild(iconToElement(this.icon));
+            icon.setAttribute('aria-hidden','true'); //otherwise screen readers could speak the icon's name
+        }
         element.appendChild(icon);
 
         let labelContainer = document.createElement('span');
@@ -71,7 +79,8 @@ class Item {
         element.appendChild(labelContainer);
 
         if(ItemType.Nested == this.type) {
-            element.appendChild(Menu.iconGenerator('chevron_right'))
+            element.appendChild(Menu.iconGenerator('chevron_right'));
+            element.setAttribute('aria-haspopup','true'); //since this opens a submenu, it needs aria-haspopup
         }
 
         if(this.id)
@@ -463,6 +472,7 @@ function materialIcon(name) {
     const icon = document.createElement('i');
     icon.className = 'material-icons';
     icon.innerHTML = name;
+    icon.setAttribute('aria-hidden','true'); //otherwise screen readers will read the icon, and the text might read inconsistently here across screen readers, with the icon
     return icon;
 }
 

--- a/src/Menu.js
+++ b/src/Menu.js
@@ -46,9 +46,7 @@ class Item {
 
         let element = document.createElement('button');
         element.className  = `menu-item menu-item__${this.type}`;
-        element.setAttribute('role','menuitem');
-        // element.setAttribute('title', this.label); // removed title because it'll be redundant in some screen readers, and not available to keyboard-only users
-    
+        element.setAttribute('role','menuitem');    
         let icon = document.createElement('span');
         icon.className = "menu-item-icon";
         if(this.icon) {

--- a/src/example.js
+++ b/src/example.js
@@ -37,6 +37,7 @@ function run() {
 
     const button = document.createElement('button');
     button.innerHTML = 'Show Menu';
+    button.setAttribute('aria-haspopup','true'); // since this button spawns an ARIA menu, set aria-haspopup
     button.addEventListener('click', (e)=>{
         const rect = e.currentTarget.getBoundingClientRect();
         const top = rect.top + rect.height + 8;


### PR DESCRIPTION
Did the following:
- added aria-haspopup to the example button and to any menuitem that spawns a submenu.
- commented out the title attr here because it duplicates the existing menuitem inner text, and won't be available without the mouse.
- hid icons from screen readers using aria-hidden
- used aria-label to provide more context to menuitems that go back a level
- added aria-label to icon menuitems since that will override any labeling weirdness that the inner text of the icon fonts could introduce